### PR TITLE
cpr - automatic search for a certificate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ set_property(GLOBAL PROPERTY PREDEFINED_TARGETS_FOLDER "CMake")
 project(cpr LANGUAGES CXX C VERSION 1.4.0)
 
 if(NOT ${CMAKE_VERSION} VERSION_LESS 3.2)
-    set(CMAKE_CXX_STANDARD 11)
+    set(CMAKE_CXX_STANDARD 17)
     set(CMAKE_CXX_STANDARD_REQUIRED ON)
 else()
     message(STATUS "Checking compiler flags for C++11 support.")

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <fstream>
+#include <filesystem>
 #include <functional>
 #include <string>
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -84,7 +84,7 @@ Session::Impl::Impl() {
         curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 50L);
         curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_->error);
         curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");
-        
+
 #ifdef __linux__
 
         static bool found = false;
@@ -510,12 +510,7 @@ Response Session::Impl::makeDownloadRequest(CURL* curl, std::ofstream& file) {
 
     auto header = cpr::util::parseHeader(header_string);
     return Response{static_cast<std::int32_t>(response_code),
-                    std::string{},
-                    header,
-                    raw_url,
-                    elapsed,
-                    cookies,
-                    error};
+        std::string{}, header, raw_url, elapsed, cookies, error};
 }
 
 Response Session::Impl::makeRequest(CURL* curl) {
@@ -535,8 +530,8 @@ Response Session::Impl::makeRequest(CURL* curl) {
 
 #if LIBCURL_VERSION_MAJOR >= 7
 #if LIBCURL_VERSION_MINOR >= 21
-    /* enable all supported built-in compressions */
-    curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
+        /* enable all supported built-in compressions */
+        curl_easy_setopt(curl, CURLOPT_ACCEPT_ENCODING, "");
 #endif
 #endif
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -87,11 +87,10 @@ Session::Impl::Impl() {
 
 #ifdef __linux__
 
-        static bool found = false;
         static const char* cert_path = nullptr;
 
         // Find the system certificate store
-        if (!found) {
+        if (cert_path == nullptr) {
             // List of possible paths:
             // https://github.com/cpp-pm/curl/blob/25d45e89d140d6ab27103cd7f8f6d7d6cf548d47/CMakeLists.txt#L919
             static constexpr const char* certificatePaths[] = {
@@ -101,7 +100,6 @@ Session::Impl::Impl() {
 
             for (const auto& path : certificatePaths) {
                 if (std::filesystem::exists(path)) {
-                    found = true;
                     cert_path = path;
                     break;
                 }

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -2,8 +2,8 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <fstream>
 #include <filesystem>
+#include <fstream>
 #include <functional>
 #include <string>
 

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -94,7 +94,6 @@ Session::Impl::Impl() {
 
         for (const auto& path : certificatePaths) {
             if (std::filesystem::exists(path)) {
-                curl_easy_setopt(curl, CURLOPT_SSLCERT, path);
                 curl_easy_setopt(curl, CURLOPT_CAINFO, path);
                 break;
             }

--- a/cpr/session.cpp
+++ b/cpr/session.cpp
@@ -84,20 +84,35 @@ Session::Impl::Impl() {
         curl_easy_setopt(curl, CURLOPT_MAXREDIRS, 50L);
         curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, curl_->error);
         curl_easy_setopt(curl, CURLOPT_COOKIEFILE, "");
+        
 #ifdef __linux__
-        // list of possible paths:
-        // https://github.com/cpp-pm/curl/blob/25d45e89d140d6ab27103cd7f8f6d7d6cf548d47/CMakeLists.txt#L919
-        static constexpr const char* certificatePaths[] = {
-                "/etc/ssl/certs/ca-certificates.crt", "/etc/pki/tls/certs/ca-bundle.crt",
-                "/usr/share/ssl/certs/ca-bundle.crt", "/usr/local/share/certs/ca-root-nss.crt",
-                "/etc/ssl/cert.pem"};
 
-        for (const auto& path : certificatePaths) {
-            if (std::filesystem::exists(path)) {
-                curl_easy_setopt(curl, CURLOPT_CAINFO, path);
-                break;
+        static bool found = false;
+        static const char* cert_path = nullptr;
+
+        // Find the system certificate store
+        if (!found) {
+            // List of possible paths:
+            // https://github.com/cpp-pm/curl/blob/25d45e89d140d6ab27103cd7f8f6d7d6cf548d47/CMakeLists.txt#L919
+            static constexpr const char* certificatePaths[] = {
+                    "/etc/ssl/certs/ca-certificates.crt", "/etc/pki/tls/certs/ca-bundle.crt",
+                    "/usr/share/ssl/certs/ca-bundle.crt", "/usr/local/share/certs/ca-root-nss.crt",
+                    "/etc/ssl/cert.pem"};
+
+            for (const auto& path : certificatePaths) {
+                if (std::filesystem::exists(path)) {
+                    found = true;
+                    cert_path = path;
+                    break;
+                }
             }
         }
+
+        // Set certificate path
+        if (cert_path != nullptr) {
+            curl_easy_setopt(curl, CURLOPT_CAINFO, cert_path);
+        }
+
 #endif
 
 #ifdef CPR_CURL_NOSIGNAL


### PR DESCRIPTION
This PR adds a functionality to automatically search for communication certificates on a system. This is especially useful when the `libcurl` library is built on one system but used on a different system. Since the path to the certificate is found at compile-time, using the compiled `libcurl` library on a different system can lead to errors, as the library won't find the certificate where it expects it.

The added piece of code searches for the certificate at common locations (exactly those [hardcoded](https://github.com/curl/curl/blob/9cb7f08ef1d13c28eebcdda2fe17b182043fdfcd/CMakeLists.txt#L1225) into the libcurl library). It only does that on Linux-based operating systems, we did not encounter the same issues on neither macOS or  Windows.